### PR TITLE
Add optional longer time period for target calculation

### DIFF
--- a/model/config.py
+++ b/model/config.py
@@ -12,6 +12,7 @@ INGESTED_DATA = "gw_raw.csv"
 FEATURE_DATA = "features_df.csv"
 PREDICTIONS = "predictions.csv"
 PAST_WEEKS_NUM = [1, 3, 6, 12]
+TARGET_WEEKS_INTO_FUTURE = 6
 BASE_FEATURES = ['assists', 'bonus', 'bps', 'clean_sheets', 'creativity',
                  'goals_conceded', 'goals_scored', 'ict_index', 'influence',
                  'minutes', 'own_goals', 'penalties_missed', 'penalties_saved', 'red_cards', 'saves',

--- a/model/config.py
+++ b/model/config.py
@@ -12,6 +12,7 @@ INGESTED_DATA = "gw_raw.csv"
 FEATURE_DATA = "features_df.csv"
 PREDICTIONS = "predictions.csv"
 PAST_WEEKS_NUM = [1, 3, 6, 12]
+TARGET_TYPE = "AVG"
 TARGET_WEEKS_INTO_FUTURE = 6
 BASE_FEATURES = ['assists', 'bonus', 'bps', 'clean_sheets', 'creativity',
                  'goals_conceded', 'goals_scored', 'ict_index', 'influence',

--- a/model/feature_engineer.py
+++ b/model/feature_engineer.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 import os
-from config import RAW_DATA_PATH, INGESTED_DATA, FEATURE_DATA, PAST_WEEKS_NUM, BASE_FEATURES, TARGET_WEEKS_INTO_FUTURE
+from config import RAW_DATA_PATH, INGESTED_DATA, FEATURE_DATA, PAST_WEEKS_NUM, BASE_FEATURES, TARGET_TYPE, TARGET_WEEKS_INTO_FUTURE
 
 
 def create_index(df):
@@ -28,6 +28,19 @@ def add_own_team_features(df):
     return df
 
 
+def create_target(gw_df, target_type, target_weeks_into_future):
+  # Positive integer -> we will take an average of scores over that many weeks in subsequent gameweeks
+  if target_type.upper() == "AVG" and isinstance(target_weeks_into_future, int) and target_weeks_into_future > 0:
+    target = gw_df.groupby(level=0)['total_points'].shift(0).rolling(target_weeks_into_future).mean().shift(-target_weeks_into_future)
+  # 0 or negative -> we will take the exponential average of all subsequent gameweek scores
+  elif target_type.upper() == "EWM":
+    target = gw_df.groupby(level=0)['total_points'].shift(-1).sort_index(ascending=False).shift(0).ewm(com=1).mean().sort_index(ascending=True)
+  # Default to target being the next gameweek's scpre
+  else:
+    target = gw_df.groupby(level=0)['total_points'].shift(-1)
+  return target
+    
+
 def create_feature_over_time(base_features, past_weeks_num, features_df, base_features_df):
     for feat in base_features:
         for x in past_weeks_num:
@@ -43,6 +56,7 @@ def create_feature_over_time(base_features, past_weeks_num, features_df, base_fe
     return features_df
 
 
+
 def main():
     gw_df = pd.read_csv(os.path.join(RAW_DATA_PATH, INGESTED_DATA)).drop_duplicates()
 
@@ -54,12 +68,7 @@ def main():
 
     features_df = gw_df_filtered[['element_type', 'is_home']]
 
-    # Positive integer -> we will take an average of scores over that many weeks in subsequent gameweeks
-    if TARGET_WEEKS_INTO_FUTURE > 0:
-      features_df['target'] = gw_df_filtered.groupby(level=0)['total_points'].shift(0).rolling(TARGET_WEEKS_INTO_FUTURE).mean().shift(-TARGET_WEEKS_INTO_FUTURE)
-    # 0 or negative -> we will take the exponential average of all subsequent gameweek scores
-    else:
-      features_df['target'] = gw_df_filtered.groupby(level=0)['total_points'].shift(-1).sort_index(ascending=False).shift(0).ewm(com=1).mean().sort_index(ascending=True)
+    features_df['target'] = create_target(gw_df_filtered, TARGET_TYPE, TARGET_WEEKS_INTO_FUTURE)
 
     features_with_time_df = create_feature_over_time(base_features=BASE_FEATURES, past_weeks_num=PAST_WEEKS_NUM,
                                                      features_df=features_df, base_features_df=gw_df_filtered)

--- a/model/feature_engineer.py
+++ b/model/feature_engineer.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 import os
-from config import RAW_DATA_PATH, INGESTED_DATA, FEATURE_DATA, PAST_WEEKS_NUM, BASE_FEATURES
+from config import RAW_DATA_PATH, INGESTED_DATA, FEATURE_DATA, PAST_WEEKS_NUM, BASE_FEATURES, TARGET_WEEKS_INTO_FUTURE
 
 
 def create_index(df):
@@ -53,7 +53,13 @@ def main():
     gw_df_filtered = gw_df_team_features[BASE_FEATURES + ['is_home', 'element_type']]
 
     features_df = gw_df_filtered[['element_type', 'is_home']]
-    features_df['target'] = gw_df_filtered.groupby(level=0)['total_points'].shift(-1)
+
+    # Positive integer -> we will take an average of scores over that many weeks in subsequent gameweeks
+    if TARGET_WEEKS_INTO_FUTURE > 0:
+      features_df['target'] = gw_df_filtered.groupby(level=0)['total_points'].shift(0).rolling(TARGET_WEEKS_INTO_FUTURE).mean().shift(-TARGET_WEEKS_INTO_FUTURE)
+    # 0 or negative -> we will take the exponential average of all subsequent gameweek scores
+    else:
+      features_df['target'] = gw_df_filtered.groupby(level=0)['total_points'].shift(-1).sort_index(ascending=False).shift(0).ewm(com=1).mean().sort_index(ascending=True)
 
     features_with_time_df = create_feature_over_time(base_features=BASE_FEATURES, past_weeks_num=PAST_WEEKS_NUM,
                                                      features_df=features_df, base_features_df=gw_df_filtered)

--- a/model/modeller.py
+++ b/model/modeller.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from sklearn.preprocessing import StandardScaler
 from sklearn import ensemble
-from config import RAW_DATA_PATH, FEATURE_DATA, PREDICTIONS
+from config import RAW_DATA_PATH, FEATURE_DATA, PREDICTIONS, TARGET_WEEKS_INTO_FUTURE
 import os
 
 
@@ -23,9 +23,9 @@ def main():
         # Train-test split
         X = players_in_pos.drop('target', axis=1)
         y = players_in_pos['target']
-        X_train = X.groupby(level=0).apply(lambda x: x.iloc[:-1])
+        X_train = X.groupby(level=0).apply(lambda x: x.iloc[:-min(1, TARGET_WEEKS_INTO_FUTURE)])
         X_test = X.groupby(level=0).tail(1)
-        y_train = y.groupby(level=0).apply(lambda x: x.iloc[:-1])
+        y_train = y.groupby(level=0).apply(lambda x: x.iloc[:-min(1, TARGET_WEEKS_INTO_FUTURE)])
 
         # Normalize
         scaler = StandardScaler()

--- a/model/modeller.py
+++ b/model/modeller.py
@@ -23,7 +23,6 @@ def main():
         # Train-test split
         X = players_in_pos.drop('target', axis=1)
         y = players_in_pos['target']
-        # Figure this out
         X_train = X.groupby(level=0).apply(lambda x: x.iloc[:-min(1, TARGET_WEEKS_INTO_FUTURE)])
         X_test = X.groupby(level=0).tail(1)
         y_train = y.groupby(level=0).apply(lambda x: x.iloc[:-min(1, TARGET_WEEKS_INTO_FUTURE)])

--- a/model/modeller.py
+++ b/model/modeller.py
@@ -23,6 +23,7 @@ def main():
         # Train-test split
         X = players_in_pos.drop('target', axis=1)
         y = players_in_pos['target']
+        # Figure this out
         X_train = X.groupby(level=0).apply(lambda x: x.iloc[:-min(1, TARGET_WEEKS_INTO_FUTURE)])
         X_test = X.groupby(level=0).tail(1)
         y_train = y.groupby(level=0).apply(lambda x: x.iloc[:-min(1, TARGET_WEEKS_INTO_FUTURE)])


### PR DESCRIPTION
Added `TARGET_WEEKS_INTO_FUTURE` variable to config which when:

- Positive - Target is an average of the player's scores over the next `TARGET_WEEKS_INTO_FUTURE` gameweeks,
- Zero / Negative - Target is an exponential average of scores in all subsequent gameweeks.